### PR TITLE
Hotfix/report toolbar

### DIFF
--- a/client/css/dashboard.css
+++ b/client/css/dashboard.css
@@ -15,7 +15,7 @@ main > nav {
 	position: sticky;
 	top: 0;
 	overflow-y: auto;
-	z-index: 5;
+	z-index: 6;
 	height: calc(100vh - 50px);
 	background: var(--color-primary);
 	color: var(--color-primary-text);
@@ -51,7 +51,7 @@ main > nav.collapsed .selected {
 	nav.collapsed > .item > .submenu {
 		position: absolute;
 		left: 100%;
-		width: 180px;
+		width: 220px;
 		top: 0;
 		background: var(--color-primary);
 		box-shadow: 0 0 25px rgba(0, 0, 0, 0.25);
@@ -127,10 +127,7 @@ main > nav::-webkit-scrollbar-track {
 				transform: rotate(90deg);
 			}
 	main > nav footer {
-		display: flex;
-		justify-content: space-between;
 		margin-top: auto;
-		background: var(--color-primary);
 	}
 		.collapsed-grid .collapse-panel {
 			display: flex;
@@ -140,26 +137,20 @@ main > nav::-webkit-scrollbar-track {
 			color: #fff;
 		}
 	 	main > nav footer .collapse-panel {
-			display: flex;
-			padding: 12px 0;
-			justify-content: flex-end;
-			width: 50px;
-			margin-left: auto;
-			margin-right: 10px;
+			padding: calc(var(--gap) * 2);
+			color: #ccc;
 		}
 		main > nav footer .collapse-panel:hover {
 			cursor: pointer;
-			background: rgba(0, 0, 0, 0.15)
+			background: rgba(0, 0, 0, 0.15);
 		}
-		main > nav footer .powered-by {
-			font-size: 80%;
-			color: #ccc;
-			letter-spacing: 0.5px;
-			padding: 12px;
-		}
-			main > nav footer .powered-by a {
-				color: var(--color-primary-text);
-			}
+
+main .section h1.dashboard-name {
+	border: 0;
+	font-size: 150%;
+	border-bottom:  1px dashed #ccc;
+}
+
 main #mailto.selected {
 	background: var(--color-accent);
 	color: var(--color-accent-text);
@@ -208,41 +199,45 @@ main #reports > .datasets .dataset-container {
 	max-width: 100%;
 	margin-top: calc(var(--gap) * 2);
 }
-	main #reports > .datasets .global-filter-head {
-		padding: 10px 0px;
+	main #reports > .datasets > .head {
+		padding: var(--gap) 0;
 		border-bottom: 1px solid #ccc;
 		width: 100%;
-		font-weight: bold;
 		display: flex;
 		align-items: center;
 		letter-spacing: 0.5px;
 	}
-		main #reports > .datasets .global-filter-head.heading {
-			position: sticky;
-			top: 0;
-			background: #fff;
-			z-index: 1;
+	main #reports > .datasets > .head.heading {
+		position: sticky;
+		top: 0;
+		background: #fff;
+		z-index: 1;
+		display: flex;
+	}
+		main #reports > .datasets > .head label {
+			grid-auto-flow: column;
+			font-size: 90%;
+			align-items: center;
 		}
-			main #reports > .datasets .global-filter-head input[type=text] {
+			main #reports > .datasets > .head input[type=search] {
 				border: 0;
-				font-size: medium;
-				outline: 0;
 				width: 100%;
+				outline: 0;
 			}
-		main #reports > .datasets .global-filter-head.heading svg {
+		main #reports > .datasets > .head.heading svg {
 			color: #999;
-}
-			main #reports > .datasets .global-filter-head .reload {
+		}
+			main #reports > .datasets > .head .reload {
 				margin-left: auto;
 				width: 30px;
 				display: flex;
 				justify-content: center;
 			}
-			main #reports > .datasets .global-filter-head input[type=checkbox]:checked {
+			main #reports > .datasets > .head input[type=checkbox]:checked {
 				color: var(--color-accent);
 				border: 3px solid blue;
 			}
-			main #reports > .datasets .global-filter-head .reload svg {
+			main #reports > .datasets > .head .reload svg {
 				margin: 0;
 			}
 	main #reports > .datasets .dataset-container:last-of-type {
@@ -269,6 +264,9 @@ main #reports > .datasets .dataset-container {
 			color: #fff;
 			font-weight: bold;
 			letter-spacing: 0.5px;
+			transition: background var(--transition-duration),
+						box-shadow var(--transition-duration),
+						color var(--transition-duration);
 		}
 		main #reports > .datasets .actions .apply:hover {
 			background: #fff;
@@ -280,8 +278,8 @@ main #reports > .list {
 	display: grid;
 	grid-template-columns: repeat(32, 1.25fr);
 	grid-auto-rows: calc(50px - (var(--gap) * 4));
-	grid-column-gap: calc(var(--gap) * 4);
-	grid-row-gap: calc(var(--gap) * 4);
+	grid-column-gap: calc(var(--gap) * 5);
+	grid-row-gap: calc(var(--gap) * 5);
 	align-items: start;
 }
 	main #reports > .list .NA.no-reports {
@@ -292,6 +290,7 @@ main #reports > .list {
 		top: 0;
 		z-index: 5;
 		align-items: flex-end;
+		background: transparent;
 	}
 		main #reports > .toolbar input[name=date-range] {
 			width: 250px;
@@ -396,11 +395,14 @@ main #reports > .list {
 			display: initial;
 		}
 		main .singleton .data-source .visualization {
-			max-height: 480px;
+			max-height: 500px;
 		}
-		main .singleton .data-source .visualization.table {
-			max-height: calc(100vh - 270px);
-		}
+			main .singleton .data-source .visualization.spatial-map {
+				max-height: calc(100vh - 190px);
+			}
+			main .singleton .data-source .visualization.table {
+				max-height: calc(100vh - 180px);
+			}
 
 main #reports > .NA {
 	text-align: center;
@@ -415,82 +417,36 @@ main #reports #blanket{
 	z-index: 5;
 }
 
-main footer.site-footer {
+main > footer {
 	grid-column: 2 / -1;
 	z-index: 5;
 	background: var(--color-primary);
-	height: 25px;
 	display: flex;
 	color: #ccc;
-	align-items: center;
-	padding: calc(var(--gap) * 2);
+	padding: calc(var(--gap) );
 	justify-content: center;
 	font-size: 80%;
-	letter-spacing: 0.5px;
-	width: 100%;
 	margin-top: auto;
 	position: relative;
 }
-	main footer.site-footer a {
-		color: #fff;
+	main footer.site-footer .strong {
+		color: var(--color-primary-text);
+		letter-spacing: 0.5px;
 	}
-	main footer .debug-info {
+	main footer > .env {
 		position: absolute;
-		right: 0;
-		background: transparent;
-		transition: width var(--transition-duration);
-		width: 15px;
+		right: 5px;
 		white-space: nowrap;
 		overflow: hidden;
-		cursor: pointer;
 	}
-	main footer .debug-info:hover {
+	main footer > .env:hover {
 		width: initial;
 	}
-	main footer .debug-info:hover .debug-text {
-		display: initial;
-	}
-		main footer .debug-info svg {
-			color: #bbb;
-			cursor: pointer;
-			padding: 1px;
-			margin-left: auto;
+		main footer > .env .text {
+			font-size: 90%;
 			margin-right: 5px;
+			display: none;
 		}
-
-	main footer .debug-text {
-		font-weight: normal;
-		z-index: 5;
-		font-size: 90%;
-		margin-right: 5px;
-		display: none;
-	}
-		main footer .debug-text .strong {
-			color: var(--color-primary-text);
-			font-weight:normal;
+		main footer > .env:hover .text {
+			display: initial;
 		}
-
-.daterangepicker .range_inputs {
-	display: flex;
-}
-	.daterangepicker input {
-		border-radius: 0 !important;
-	}
-	.daterangepicker button {
-		color: #333 !important;
-		border-radius: 0;
-		flex: 1;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		letter-spacing: 1px;
-		font-size: 11px !important;
-	}
-	.daterangepicker .ranges li {
-		border-radius: 0;
-	}
-
-main .section h1.dashboard-name {
-	border: 0;
-	font-size: 200%;
-}

--- a/client/css/dashboard.css
+++ b/client/css/dashboard.css
@@ -1,5 +1,6 @@
 main {
 	display: grid !important;
+	grid-template-rows: 1fr max-content;
 	grid-template-columns: 220px calc(100% - 220px);
 }
 main.collapsed-grid {
@@ -141,9 +142,10 @@ main > nav::-webkit-scrollbar-track {
 	 	main > nav footer .collapse-panel {
 			display: flex;
 			padding: 12px 0;
-			justify-content: center;
-			align-items: center;
+			justify-content: flex-end;
 			width: 50px;
+			margin-left: auto;
+			margin-right: 10px;
 		}
 		main > nav footer .collapse-panel:hover {
 			cursor: pointer;
@@ -200,27 +202,49 @@ main #reports > .datasets.show {
 	opacity: 1;
 }
 
-	main #reports > .datasets h3 {
-		margin: 0 0 10px;
-		border-bottom: 1px dashed #999;
-		font-size: 95%;
-		padding: calc(var(--gap)* 2) 0;
-		background: #fff;
+main #reports > .datasets .dataset-container {
+	grid-column: 1;
+	width: 100%;
+	max-width: 100%;
+	margin-top: calc(var(--gap) * 2);
+}
+	main #reports > .datasets .global-filter-head {
+		padding: 10px 0px;
+		border-bottom: 1px solid #ccc;
 		width: 100%;
-		position: sticky;
+		font-weight: bold;
+		display: flex;
+		align-items: center;
 		letter-spacing: 0.5px;
-		top: 0;
-		z-index: 1;
 	}
-		main #reports > .datasets h3 svg {
-			color: #999;
+		main #reports > .datasets .global-filter-head.heading {
+			position: sticky;
+			top: 0;
+			background: #fff;
+			z-index: 1;
 		}
-	main #reports > .datasets .dataset-container {
-		grid-column: 1;
-		width: 100%;
-		max-width: 100%;
-		margin-bottom: calc(var(--gap) * 2);
-	}
+			main #reports > .datasets .global-filter-head input[type=text] {
+				border: 0;
+				font-size: medium;
+				outline: 0;
+				width: 100%;
+			}
+		main #reports > .datasets .global-filter-head.heading svg {
+			color: #999;
+}
+			main #reports > .datasets .global-filter-head .reload {
+				margin-left: auto;
+				width: 30px;
+				display: flex;
+				justify-content: center;
+			}
+			main #reports > .datasets .global-filter-head input[type=checkbox]:checked {
+				color: var(--color-accent);
+				border: 3px solid blue;
+			}
+			main #reports > .datasets .global-filter-head .reload svg {
+				margin: 0;
+			}
 	main #reports > .datasets .dataset-container:last-of-type {
 		margin-bottom: 0;
 	}
@@ -240,8 +264,16 @@ main #reports > .datasets.show {
 		width: 100%;
 		padding: calc(var(--gap) * 2) 0;
 	}
-		main #reports > .datasets .actions .icon svg {
-			margin: 0;
+		main #reports > .datasets .actions .apply {
+			background: var(--color-accent);
+			color: #fff;
+			font-weight: bold;
+			letter-spacing: 0.5px;
+		}
+		main #reports > .datasets .actions .apply:hover {
+			background: #fff;
+			color: var(--color-accent);
+			cursor: pointer;
 		}
 
 main #reports > .list {
@@ -383,6 +415,61 @@ main #reports #blanket{
 	z-index: 5;
 }
 
+main footer.site-footer {
+	grid-column: 2 / -1;
+	z-index: 5;
+	background: var(--color-primary);
+	height: 25px;
+	display: flex;
+	color: #ccc;
+	align-items: center;
+	padding: calc(var(--gap) * 2);
+	justify-content: center;
+	font-size: 80%;
+	letter-spacing: 0.5px;
+	width: 100%;
+	margin-top: auto;
+	position: relative;
+}
+	main footer.site-footer a {
+		color: #fff;
+	}
+	main footer .debug-info {
+		position: absolute;
+		right: 0;
+		background: transparent;
+		transition: width var(--transition-duration);
+		width: 15px;
+		white-space: nowrap;
+		overflow: hidden;
+		cursor: pointer;
+	}
+	main footer .debug-info:hover {
+		width: initial;
+	}
+	main footer .debug-info:hover .debug-text {
+		display: initial;
+	}
+		main footer .debug-info svg {
+			color: #bbb;
+			cursor: pointer;
+			padding: 1px;
+			margin-left: auto;
+			margin-right: 5px;
+		}
+
+	main footer .debug-text {
+		font-weight: normal;
+		z-index: 5;
+		font-size: 90%;
+		margin-right: 5px;
+		display: none;
+	}
+		main footer .debug-text .strong {
+			color: var(--color-primary-text);
+			font-weight:normal;
+		}
+
 .daterangepicker .range_inputs {
 	display: flex;
 }
@@ -402,3 +489,8 @@ main #reports #blanket{
 	.daterangepicker .ranges li {
 		border-radius: 0;
 	}
+
+main .section h1.dashboard-name {
+	border: 0;
+	font-size: 200%;
+}

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -111,7 +111,6 @@ body {
 	display: flex;
 	margin: 0;
 	flex-direction: column;
-	background: #eee;
 	user-select: none;
 	font-size: 14px !important;
 	color: #222;
@@ -284,7 +283,7 @@ body {
 		display: block;
 	}
 		main section .toolbar {
-			background: #eee;
+			background: #fff;
 			display: grid;
 			grid-gap: calc(var(--gap) * 2);
 			grid-auto-columns: max-content;

--- a/client/css/reports-manager.css
+++ b/client/css/reports-manager.css
@@ -400,12 +400,12 @@ main.preview-left #stages {
 		cursor: pointer;
 		position: sticky;
 		top: 28px;
-		background: #eee;
 		padding: var(--gap);
 		margin: calc(var(--gap) * 2) 0;
 		display: flex;
 		align-items: center;
 		font-size: 95%;
+		background: #fff;
 		z-index: 1;
 	}
 		#stage-configure-visualization h3 > svg {

--- a/client/css/reports.css
+++ b/client/css/reports.css
@@ -75,8 +75,7 @@ main .data-source {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	background: #fff;
-	box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
 }
 main .data-source:hover {
 	box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
@@ -155,6 +154,19 @@ main .data-source:hover {
 		}
 	main .data-source .toolbar.filters {
 		grid-template-columns: repeat(auto-fit, minmax(150px, max-content));
+		background: rgba(255, 255, 255, 0.8);
+		position: absolute;
+		border-top: 1px solid #ccc;
+		bottom: 0;
+		top: 80px;
+		z-index: 1;
+		left: 0;
+		right: 0;
+		overflow: auto;
+		max-height:  100%;
+		margin: 0;
+		padding: calc(var(--gap) * 2);
+		align-items: flex-start;
 	}
 		main .data-source .menu-toggle.selected,
 		main .data-source .query-toggle.selected,
@@ -196,6 +208,16 @@ main .data-source:hover {
 		}
 	main .data-source > .description {
 	border-top: 1px solid #ccc;
+	background: rgba(255, 255, 255, 0.8);
+	position: absolute;
+	bottom: 0;
+	top: 80px;
+	z-index: 1;
+	l;
+	left: 0;
+	right: 0;
+	display: flex;
+	flex-direction:  column;
 	}
 		main .data-source > .description .body {
 			white-space: pre-wrap;
@@ -214,6 +236,8 @@ main .data-source:hover {
 			padding: 10px;
 			font-size: 90%;
 			display: flex;
+			margin-top:  auto;
+			background: rgba(255, 255, 255, 0.5);
 		}
 			main .data-source > .description .footer > * {
 				margin-right: calc(var(--gap) * 2);
@@ -228,8 +252,9 @@ main .data-source:hover {
 				color: #333;
 				cursor: pointer;
 			}
-			main .data-source > .description .footer .visible-to:hover {
+			main .data-source > .description .footer .visible-to .count:hover {
 				text-decoration: underline;
+				cursor: pointer;
 			}
 			main .data-source > .description .footer .label {
 				font-size: 100%;
@@ -239,9 +264,19 @@ main .data-source:hover {
 		padding: 10px;
 		user-select: text;
 		font-family: monospace;
-		max-height: 150px;
+		max-height: 100%;
 		overflow: auto;
 		border-top: 1px solid #ccc;
+		background: rgba(255, 255, 255, 0.8);
+		position: absolute;
+		bottom: 0;
+		top: 0;
+		z-index: 1;
+		left: 0;
+		right: 0;
+		display: flex;
+		flex-direction: column;
+		top: 80px;
 	}
     main .data-source > .export-json {
           background: #fff;
@@ -310,6 +345,10 @@ main .data-source:hover {
 		order: 1;
 		padding: 0 var(--gap);
 		height: 37px;
+		transition: filter var(--transition-duration);
+	}
+	main .data-source > .columns.blur {
+		filter: blur(2px);
 	}
 	main .data-source > .columns.over-flow::after {
 		background: -webkit-linear-gradient(left, #eee, #ccc);
@@ -318,6 +357,7 @@ main .data-source:hover {
 		right: 0;
 		margin-left: auto;
 		width: 50px;
+		display: none;
 	}
 	main .data-source > .columns::-webkit-scrollbar {
 		display: none;
@@ -494,6 +534,10 @@ main .data-source:hover {
 		position: relative;
 		flex: 1;
 		background: #f1f1f1;
+		transition: filter var(--transition-duration);
+	}
+	main .data-source .visualization.blur {
+		filter: blur(2px);
 	}
 		main .data-source .visualization .NA {
 			padding: 8px 16px;
@@ -609,6 +653,7 @@ main .data-source:hover {
 			.visualization.table table {
 				caption-side: bottom;
 				margin-bottom:  24px;
+				background: #fff;
 			}
 			.visualization.table thead tr.search {
 				background: #fff;
@@ -761,61 +806,61 @@ main .data-source:hover {
 		.visualization.spatial-map .container {
 			height: 500px;
 		}
-			.visualization.cohort {
-				overflow: auto;
+		.visualization.cohort {
+			overflow: auto;
+		}
+		.visualization.cohort table {
+			width: 100%;
+		}
+			.visualization.cohort table td:first-child,
+			.visualization.cohort table th:first-child {
+				white-space: nowrap;
+				min-width: 100px;
+				border: 0;
 			}
-			.visualization.cohort table {
-				width: 100%;
+			.visualization.cohort table th.sticky,
+			.visualization.cohort table td.sticky {
+				position: sticky;
+				left: 0;
+				top: 0;
 			}
-				.visualization.cohort table td:first-child,
-				.visualization.cohort table th:first-child {
-					white-space: nowrap;
-					min-width: 100px;
-					border: 0;
+			.visualization.cohort table th.sticky {
+				z-index: 2;
+				background: var(--color-primary);
+			}
+			.visualization.cohort table td.sticky {
+				background: #fff;
+			}
+			.visualization.cohort table td.sticky:nth-child(2n) {
+				background: #f1f1f9;
+			}
+			.visualization.cohort table .sticky:nth-child(2) {
+				left: 100px;
+			}
+			.visualization.cohort th {
+				white-space: nowrap;
+			}
+			.visualization.cohort td {
+				text-align: center;
+			}
+			.visualization.cohort td.href {
+				padding: 0;
+			}
+				.visualization.cohort td a {
+					color: #333;
+					display: block;
+					padding: 8px 15px;
+					transition: background var(--transition-duration),
+								box-shadow var(--transition-duration);
 				}
-				.visualization.cohort table th.sticky,
-				.visualization.cohort table td.sticky {
-					position: sticky;
-					left: 0;
-					top: 0;
+				.visualization.cohort td a:focus,
+				.visualization.cohort td a:hover {
+					background: rgba(0, 0, 0, 0.3);
+					text-decoration: none;
 				}
-				.visualization.cohort table th.sticky {
-					z-index: 2;
-					background: var(--color-primary);
+				.visualization.cohort td a:active {
+					box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.4);
 				}
-				.visualization.cohort table td.sticky {
-					background: #fff;
-				}
-				.visualization.cohort table td.sticky:nth-child(2n) {
-					background: #f1f1f9;
-				}
-				.visualization.cohort table .sticky:nth-child(2) {
-					left: 100px;
-				}
-				.visualization.cohort th {
-					white-space: nowrap;
-				}
-				.visualization.cohort td {
-					text-align: center;
-				}
-				.visualization.cohort td.href {
-					padding: 0;
-				}
-					.visualization.cohort td a {
-						color: #333;
-						display: block;
-						padding: 8px 15px;
-						transition: background var(--transition-duration),
-									box-shadow var(--transition-duration);
-					}
-					.visualization.cohort td a:focus,
-					.visualization.cohort td a:hover {
-						background: rgba(0, 0, 0, 0.3);
-						text-decoration: none;
-					}
-					.visualization.cohort td a:active {
-						box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.4);
-					}
 
 
 .visualization .container > svg {

--- a/client/index.js
+++ b/client/index.js
@@ -506,7 +506,7 @@ router.get('/:type(dashboard|report)/:id?', API.serve(class extends HTMLAPI {
 			</section>
 
 			<section class="section" id="reports">
-			
+
 				<h1 class="dashboard-name"></h1>
 
 				<div class="toolbar form">
@@ -559,14 +559,15 @@ router.get('/:type(dashboard|report)/:id?', API.serve(class extends HTMLAPI {
 					<i class="fas fa-filter"></i>
 				</button>
 			</section>
-			
-			<footer class="site-footer">
-				Powered by&nbsp;<span>${config.has("footer_powered_by") ? config.get("footer_powered_by") : ''}</span>
-						<a href="https://github.com/Jungle-Works/AllSpark" target="_blank">AllSpark</a>
-				<div class="debug-info">
-					<span class="debug-text">
+
+			<footer class="site-footer ${this.account.settings.get('disable_powered_by') ? 'disabled' : ''}">
+				Powered by&nbsp;
+				${config.has('footer_powered_by') ? config.get('footer_powered_by') : ''}
+				<a class="strong" href="https://github.com/Jungle-Works/AllSpark" target="_blank">AllSpark</a>
+				<div class="env">
+					<span class="text">
 						Env: <span class="strong">${this.env.name}</span>
-						Branch: <span class="strong">${this.env.branch}</span> 
+						Branch: <span class="strong">${this.env.branch}</span>
 						Last deployed: <span title="${this.env.deployed_on}" class="strong">${this.env.deployed_on}</span>
 					</span>
 					<i class="fas fa-exclamation-circle"></i>

--- a/client/index.js
+++ b/client/index.js
@@ -506,6 +506,8 @@ router.get('/:type(dashboard|report)/:id?', API.serve(class extends HTMLAPI {
 			</section>
 
 			<section class="section" id="reports">
+			
+				<h1 class="dashboard-name"></h1>
 
 				<div class="toolbar form">
 
@@ -557,6 +559,19 @@ router.get('/:type(dashboard|report)/:id?', API.serve(class extends HTMLAPI {
 					<i class="fas fa-filter"></i>
 				</button>
 			</section>
+			
+			<footer class="site-footer">
+				Powered by&nbsp;<span>${config.has("footer_powered_by") ? config.get("footer_powered_by") : ''}</span>
+						<a href="https://github.com/Jungle-Works/AllSpark" target="_blank">AllSpark</a>
+				<div class="debug-info">
+					<span class="debug-text">
+						Env: <span class="strong">${this.env.name}</span>
+						Branch: <span class="strong">${this.env.branch}</span> 
+						Last deployed: <span title="${this.env.deployed_on}" class="strong">${this.env.deployed_on}</span>
+					</span>
+					<i class="fas fa-exclamation-circle"></i>
+				</div>
+			</footer>
 		`;
 	}
 }));

--- a/client/js/dashboard.js
+++ b/client/js/dashboard.js
@@ -372,15 +372,12 @@ Page.class = class Dashboards extends Page {
 
 		nav.insertAdjacentHTML('beforeend', `
 			<footer>
-				<span class="powered-by hidden"> Powered By <a target="_blank" href="https://github.com/Jungle-Works/AllSpark">AllSpark</a></span>
 				<div class="collapse-panel">
 					<span class="left"><i class="fa fa-angle-double-left"></i></span>
 					<span class="right hidden"><i class="fa fa-angle-double-right"></i></span>
 				</div<
 			</footer>
 		`);
-
-		nav.querySelector('.powered-by').classList.toggle('hidden', account.settings.get('disable_powered_by'))
 
 		nav.querySelector('.collapse-panel').on('click', (e) => {
 
@@ -794,6 +791,8 @@ class Dashboard {
 
 			this.page.container.querySelector('#reports .side').classList.add('hidden');
 		}
+
+		this.page.container.querySelector('.dashboard-name').innerHTML = this.name;
 
 		await Sections.show('reports');
 
@@ -1251,7 +1250,17 @@ class DashboardDatasets extends Map {
 		if (!this.size)
 			return;
 
-		container.innerHTML = '<h3><i class="fas fa-filter"></i> Global Filters</h3>';
+		container.innerHTML = `
+			<div class="global-filter-head heading">
+				<i class="fas fa-filter"></i>
+				<input type="text" placeholder="Global Filters" class="global-filter-search">
+				<i class="fa fa-search"></i>
+			</div>
+			<div class="global-filter-head">
+				<input type="checkbox" checked>&nbsp;Select All 
+				<button class="reload icon" title="Fore Refresh"><i class="fas fa-sync"></i></button>
+			</div>
+		`;
 
 		const datasets = Array.from(this.values()).sort((a, b) => {
 			if (!a.order)
@@ -1280,42 +1289,37 @@ class DashboardDatasets extends Map {
 			container.appendChild(label);
 		}
 
+		const searchInput = container.querySelector('.global-filter-search');
+
+		searchInput.on('keyup', () => {
+
+			for(const dataset of this.values()) {
+
+				dataset.container.parentElement.classList.remove('hidden');
+
+				if(!dataset.name.toLowerCase().trim().includes(searchInput.value.toLowerCase().trim())) {
+
+					dataset.container.parentElement.classList.add('hidden');
+				}
+
+			}
+
+		});
+
 		container.insertAdjacentHTML('beforeend', `
 			<div class="actions">
-				<button class="apply" title="Apply Filters"><i class="fas fa-paper-plane"></i> Apply</button>
-				<button class="reload icon" title="Fore Refresh"><i class="fas fa-sync"></i></button>
-				<button class="reset-toggle clear icon" title="Clear All Filters"><i class="far fa-check-square"></i></button>
+				<button class="apply" title="Apply Filters">Apply</button>
 			</div>
 		`);
 
 		container.querySelector('button.apply').on('click', () => this.apply());
 		container.querySelector('button.reload').on('click', () => this.apply({cached: 0}));
 
-		const resetToggle = container.querySelector('button.reset-toggle');
+		const input = container.querySelector('.global-filter-head input[type=checkbox]');
 
-		resetToggle.on('click', () => {
+		input.on('change', () => {
 
-			if (resetToggle.classList.contains('check')) {
-
-				this.all();
-
-				resetToggle.classList.remove('check');
-				resetToggle.classList.add('clear');
-
-				resetToggle.title = 'Clear All Filters';
-				resetToggle.innerHTML = `<i class="far fa-check-square"></i>`;
-			}
-
-			else {
-
-				this.clear();
-
-				resetToggle.classList.add('check');
-				resetToggle.classList.remove('clear');
-
-				resetToggle.title = 'Check All Filters';
-				resetToggle.innerHTML = `<i class="far fa-square"></i>`;
-			}
+			input.checked ? this.all() : this.clear();
 		});
 	}
 

--- a/client/js/dashboard.js
+++ b/client/js/dashboard.js
@@ -388,12 +388,6 @@ Page.class = class Dashboards extends Page {
 			right.classList.toggle('hidden');
 			e.currentTarget.querySelector('.left').classList.toggle('hidden');
 
-			if(!nav.querySelector('.powered-by').classList.contains('hidden') && !account.settings.get('disable_powered_by'))
-				nav.querySelector('.powered-by').classList.add('hidden');
-
-			else if( !account.settings.get('disable_powered_by'))
-				nav.querySelector('.powered-by').classList.remove('hidden');
-
 			document.querySelector('main').classList.toggle('collapsed-grid');
 
 			for (const item of nav.querySelectorAll('.item')) {
@@ -446,6 +440,9 @@ Page.class = class Dashboards extends Page {
 		this.loadedVisualizations.clear();
 		this.loadedVisualizations.add(report);
 
+		const dashboardName = this.container.querySelector('.dashboard-name');
+		dashboardName.classList.add('hidden');
+
 		container.textContent = null;
 
 		const promises = [];
@@ -462,7 +459,7 @@ Page.class = class Dashboards extends Page {
 
 		report.container.removeAttribute('style');
 		container.classList.add('singleton');
-		this.reports.querySelector('.toolbar').classList.add('hidden');
+		Dashboard.toolbar.classList.add('hidden');
 
 		report.container.querySelector('.menu').classList.remove('hidden');
 		report.container.querySelector('.menu-toggle').classList.add('selected');
@@ -787,29 +784,26 @@ class Dashboard {
 		if (this.format && this.format.category_id)
 			return;
 
-		if (!this.datasets.size) {
-
+		if (!this.datasets.size)
 			this.page.container.querySelector('#reports .side').classList.add('hidden');
-		}
 
-		this.page.container.querySelector('.dashboard-name').innerHTML = this.name;
+		const dashboardName = this.page.container.querySelector('.dashboard-name');
+		dashboardName.innerHTML = this.name;
+		dashboardName.classList.remove('hidden');
+
+		Dashboard.toolbar.classList.remove('hidden');
 
 		await Sections.show('reports');
 
-		const menuElement = this.page.container.querySelector("#dashboard-" + this.id);
+		const menuElement = this.page.container.querySelector('#dashboard-' + this.id);
 
+		for (const element of this.page.container.querySelectorAll('.label'))
+			element.classList.remove('selected');
 
-		for (const element of this.page.container.querySelectorAll(".label")) {
+		if (menuElement)
+			menuElement.classList.add('selected');
 
-			element.classList.remove("selected");
-		}
-
-		if (menuElement) {
-
-			menuElement.classList.add("selected");
-		}
-
-		const mainObject = document.querySelector("main");
+		const mainObject = document.querySelector('main');
 
 		this.visualizationsPositionObject = {};
 
@@ -821,7 +815,7 @@ class Dashboard {
 
 			Dashboard.container.appendChild(queryDataSource.container);
 
-			Dashboard.container.classList.remove("singleton");
+			Dashboard.container.classList.remove('singleton');
 
 			this.visualizationsPositionObject[queryDataSource.selectedVisualization.visualization_id] = ({
 				position: queryDataSource.container.getBoundingClientRect().y,
@@ -849,10 +843,8 @@ class Dashboard {
 			}
 		);
 
-		if (!this.page.loadedVisualizations.size) {
-
+		if (!this.page.loadedVisualizations.size)
 			Dashboard.container.innerHTML = '<div class="NA no-reports">No reports found! :(</div>';
-		}
 
 		if (this.page.user.privileges.has('reports')) {
 
@@ -1251,20 +1243,21 @@ class DashboardDatasets extends Map {
 			return;
 
 		container.innerHTML = `
-			<div class="global-filter-head heading">
+			<div class="head heading">
 				<i class="fas fa-filter"></i>
-				<input type="text" placeholder="Global Filters" class="global-filter-search">
-				<i class="fa fa-search"></i>
+				<input type="search" placeholder="Global Filters" class="global-filter-search">
 			</div>
-			<div class="global-filter-head">
-				<input type="checkbox" checked>&nbsp;Select All 
+			<div class="head">
+				<label><input type="checkbox" checked> Select All</label>
 				<button class="reload icon" title="Fore Refresh"><i class="fas fa-sync"></i></button>
 			</div>
 		`;
 
 		const datasets = Array.from(this.values()).sort((a, b) => {
+
 			if (!a.order)
 				return 1;
+
 			if (!b.order)
 				return -1;
 
@@ -1297,13 +1290,9 @@ class DashboardDatasets extends Map {
 
 				dataset.container.parentElement.classList.remove('hidden');
 
-				if(!dataset.name.toLowerCase().trim().includes(searchInput.value.toLowerCase().trim())) {
-
+				if(!dataset.name.toLowerCase().trim().includes(searchInput.value.toLowerCase().trim()))
 					dataset.container.parentElement.classList.add('hidden');
-				}
-
 			}
-
 		});
 
 		container.insertAdjacentHTML('beforeend', `
@@ -1315,7 +1304,7 @@ class DashboardDatasets extends Map {
 		container.querySelector('button.apply').on('click', () => this.apply());
 		container.querySelector('button.reload').on('click', () => this.apply({cached: 0}));
 
-		const input = container.querySelector('.global-filter-head input[type=checkbox]');
+		const input = container.querySelector('.head input[type=checkbox]');
 
 		input.on('change', () => {
 

--- a/client/js/reports.js
+++ b/client/js/reports.js
@@ -217,7 +217,7 @@ class DataSource {
 					</span>
 					<span class="right visible-to">
 						<span class="label">Visible To</span>
-						<span class="visible-length"></span>
+						<span class="count"></span>
 					</span>
 					<span>
 						<span class="label">Added By:</span>
@@ -236,7 +236,7 @@ class DataSource {
 
 		document.querySelector('body').on('click', (e) => {
 			container.querySelector('.menu .download-btn .download-dropdown-content').classList.add('hidden');
-		this.containerElement.querySelector('.menu .download-btn .download').classList.remove('selected');
+			this.containerElement.querySelector('.menu .download-btn .download').classList.remove('selected');
 		})
 
 		container.querySelector('.menu .export-toggle').on('click', () => {
@@ -246,8 +246,21 @@ class DataSource {
 			this.visualizations.selected.render({resize: true});
 		});
 		container.querySelector('header .menu-toggle').on('click', () => {
+
 			container.querySelector('.menu').classList.toggle('hidden');
 			container.querySelector('header .menu-toggle').classList.toggle('selected');
+
+			container.querySelector('.description').classList.add('hidden');
+			container.querySelector('.description-toggle').classList.remove('selected');
+			container.querySelector('.query').classList.add('hidden');
+			container.querySelector('.query-toggle').classList.remove('selected');
+			container.querySelector('.filters-toggle').classList.remove('selected');
+
+			if(container.contains(this.filters.container))
+				container.removeChild(this.filters.container);
+
+			this.visualizations.selected.container.classList.remove('blur');
+			container.querySelector('.columns').classList.remove('blur');
 
 			this.visualizations.selected.render({resize: true});
 		});
@@ -258,7 +271,7 @@ class DataSource {
 			container.querySelector('.description .footer').classList.remove('hidden');
 		}
 
-		container.querySelector('.description .visible-to').on('click', () => {
+		container.querySelector('.description .visible-to .count').on('click', () => {
 
 			if(!this.dialog)
 				this.dialog = new DialogBox(this);
@@ -287,6 +300,8 @@ class DataSource {
 		container.querySelector('.menu .filters-toggle').on('click', () => {
 
 			container.querySelector('.filters-toggle').classList.toggle('selected');
+			this.visualizations.selected.container.classList.toggle('blur');
+			container.querySelector('.columns').classList.toggle('blur');
 
 			if(container.contains(this.filters.container))
 				container.removeChild(this.filters.container);
@@ -312,15 +327,16 @@ class DataSource {
 		container.querySelector('.menu .description-toggle').on('click', async () => {
 
 			container.querySelector('.description').classList.toggle('hidden');
-
 			container.querySelector('.description-toggle').classList.toggle('selected');
+			this.visualizations.selected.container.classList.toggle('blur');
+			container.querySelector('.columns').classList.toggle('blur');
 
 			this.visualizations.selected.render({resize: true});
 
-			if(user.privileges.has('administrator')) {
+			if(user.privileges.has('report')) {
 
 				await this.userList();
-				container.querySelector('.description .visible-length').textContent = `${this.visibleTo.length} people`;
+				container.querySelector('.description .count').textContent = `${this.visibleTo.length} people`;
 			}
 			else {
 				container.querySelector('.description .visible-to').classList.add('hidden');
@@ -331,6 +347,8 @@ class DataSource {
 
 			container.querySelector('.query').classList.toggle('hidden');
 			container.querySelector('.query-toggle').classList.toggle('selected');
+			this.visualizations.selected.container.classList.toggle('blur');
+			container.querySelector('.columns').classList.toggle('blur');
 
 			this.visualizations.selected.render({resize: true});
 		});
@@ -766,7 +784,7 @@ class DataSourceFilters extends Map {
 			<label class="right">
 				<span>&nbsp;</span>
 				<button type="submit">
-					<i class="fa fa-sync"></i> Submit
+					<i class="fas fa-paper-plane"></i> Apply
 				</button>
 			</label>
 		`);
@@ -5655,6 +5673,9 @@ Visualization.list.set('bigtext', class NumberVisualizaion extends Visualization
 
 		if(!this.column)
 			return this.source.error('Value column not selected! :(');
+
+		if(!response)
+			return this.source.error('Invalid Response! :(');
 
 		if(!response.has(this.column))
 			return this.source.error(`<em>${this.column}</em> column not found! :(`);

--- a/client/js/settings.js
+++ b/client/js/settings.js
@@ -764,6 +764,11 @@ class SettingsAccount {
 				name: 'Allow User Signup',
 			},
 			{
+				key: 'disable_powered_by',
+				type: 'toggle',
+				name: 'Disable "Powered By"',
+			},
+			{
 				key: 'custom_js',
 				type: 'code',
 				mode: 'javascript',

--- a/config/sample.json
+++ b/config/sample.json
@@ -28,5 +28,6 @@
     "port": 6379,
     "db": 0
   },
-  "superAdmin_users": ["email1", "email2"]
+  "superAdmin_users": ["email1", "email2"],
+  "footer_powered_by": ""
 }


### PR DESCRIPTION
Description:

- Added dashboard title at the top of the page.
- Added a footer on dashboard page.
- Added "powered by" to the new footer.
- Removed "powered by" from the left menu.
Added an info icon in the dashboard footer to show current deployment information like branch, environment - and deployment time.
- Added a new config property to show additional stuff in the footer.
- Added the new config property to sample config file.
- Added an option in account settings to disable powered by.
- Top Toolbar on dashboard doesn't hide when coming from an "expand"ed report to a dashboard.
- Spatial maps and table now take up the entire height on "expand"ed view of a report.
- New UI for report description (Info), Query and Filters.
- Renamed "Submit" to "Apply" in report filters UI.
- Closing a report's menu (three dots, top right) will also close any open filters, description or query.
- Report filter list now overflows with a scrollbar instead of breaking the UI.