### PR TITLE
Hotfix/refresh token

### DIFF
--- a/client/css/reports.css
+++ b/client/css/reports.css
@@ -138,6 +138,9 @@ main .dataset {
 			cursor: default;
 			box-shadow: 0 0 15px rgba(0, 0, 0, 0.15);
 		}
+		.data-source > header h2::-webkit-scrollbar {
+			display: none;
+		}
 			.data-source > header i {
 				margin-left: 5px;
 			}
@@ -171,7 +174,7 @@ main .dataset {
 		display: none;
 	}
 		.data-source .toolbar > * {
-			margin: 0 5px;
+			margin: var(--gap);
 		}
 			.data-source .toolbar .right {
 				order: 2000;
@@ -307,8 +310,6 @@ main .dataset {
 		}
 
 	.data-source .toolbar.filters {
-		grid-template-columns: repeat(auto-fit, minmax(150px, max-content));
-		margin: 0;
 		padding: 25px calc(var(--gap) * 2) calc(var(--gap) * 2);
 		align-items: flex-start;
 		flex-wrap: wrap;

--- a/client/css/reports.css
+++ b/client/css/reports.css
@@ -114,7 +114,7 @@ main .dataset {
 		display: flex;
 		align-items: center;
 		white-space: nowrap;
-		z-index: 1;
+		z-index: 3;
 	}
 	.data-source > header::-webkit-scrollbar {
 		display: none;

--- a/client/js/dashboard.js
+++ b/client/js/dashboard.js
@@ -310,10 +310,11 @@ Page.class = class Dashboards extends Page {
 
 	async load(state) {
 
-		await DataSource.load();
-
 		const
-			dashboardList = await API.call('dashboards/list'),
+			[_, dashboardList] = await Promise.all([
+				DataSource.load(),
+				API.call('dashboards/list'),
+			]),
 			currentId = state ? state.filter : parseInt(window.location.pathname.split('/').pop()),
 			[loadReport] = window.location.pathname.split('/').filter(x => x === 'report');
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1270,21 +1270,20 @@ class API extends AJAX {
 	 */
 	static async refreshToken() {
 
-		let
-			getToken = true,
-			token = await Storage.get('token');
-
 		if(Cookies.get('external_parameters')) {
+
+			await Storage.clear();
 
 			await Storage.set('external_parameters', JSON.parse(Cookies.get('external_parameters')));
 			Cookies.set('external_parameters', '');
-		}
-
-		if(Cookies.get('refresh_token')) {
 
 			await Storage.set('refresh_token', Cookies.get('refresh_token'));
 			Cookies.set('refresh_token', '');
 		}
+
+		let
+			getToken = true,
+			token = await Storage.get('token');
 
 		if(token && token.body) {
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -2129,7 +2129,7 @@ class MultiSelect {
 
 			let hide = false;
 
-			const rowValue = row.name.concat(' ', row.value, ' ', row.subtitle || '');
+			const rowValue = (row.name || '').concat(' ', row.value, ' ', row.subtitle || '');
 
 			if(search.value && !rowValue.toLowerCase().trim().includes(search.value.toLowerCase().trim()))
 				hide = true;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -2127,9 +2127,16 @@ class MultiSelect {
 
 			row.input.checked = this.selectedValues.has(row.input.value);
 
-			let hide = false;
+			let
+				hide = false,
+				name = row.name;
 
-			const rowValue = (row.name || '').concat(' ', row.value, ' ', row.subtitle || '');
+			if(!name)
+				name = '';
+
+			name = name.toString();
+
+			const rowValue = name.concat(' ', row.value, ' ', row.subtitle || '');
 
 			if(search.value && !rowValue.toLowerCase().trim().includes(search.value.toLowerCase().trim()))
 				hide = true;

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -567,7 +567,7 @@ class Cookies {
 	 * @return boolean			The status of the set request.
 	 */
 	static set(key, value) {
-		document.cookie = `${key}=${encodeURIComponent(value)}`;
+		document.cookie = `${key}=${encodeURIComponent(value)};path=/`;
 		return true;
 	}
 
@@ -1272,10 +1272,9 @@ class API extends AJAX {
 
 		let
 			getToken = true,
-			token = await Storage.get('token'),
-			has_external_parameters = await Storage.has('external_parameters');
+			token = await Storage.get('token');
 
-		if(!has_external_parameters && Cookies.get('external_parameters')) {
+		if(Cookies.get('external_parameters')) {
 
 			await Storage.set('external_parameters', JSON.parse(Cookies.get('external_parameters')));
 			Cookies.set('external_parameters', '');

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -39,9 +39,8 @@ class Page {
 
 	static async load() {
 
-		Page.loadCredentialsFromCookie();
-
 		await Storage.load();
+		await Page.loadCredentialsFromCookie();
 		await Account.load();
 
 		if(window.account && account.auth_api) {

--- a/client/js/reports-manager.js
+++ b/client/js/reports-manager.js
@@ -1897,14 +1897,14 @@ ReportsManger.stages.set('configure-visualization', class ConfigureVisualization
 		if(!this.visualization)
 			return;
 
-		await this.loadVisualizationForm();
-
 		await this.page.preview.load({
 			query_id: this.report.query_id,
 			visualization: {
 				id: this.visualization.visualization_id
 			},
 		});
+
+		await this.loadVisualizationForm();
 
 		this.visualizationLogs = new ReportLogs(this.visualization, this, {class: VisualizationLog, name: 'visualization'});
 
@@ -2303,7 +2303,7 @@ class VisualizationLog extends ReportLog {
 		logInfo.querySelector('.toolbar .preview').on('click', () => {
 
 			if(this.logsVisualizationManager) {
-				
+
 				this.logsVisualizationManager.preview();
 			}
 
@@ -2318,7 +2318,7 @@ class VisualizationLog extends ReportLog {
 
 			this.logsVisualizationManager = new VisualizationManager(this.state, this.logs.page);
 		}
-		
+
 		queryInfo.appendChild(this.logsVisualizationManager.container);
 
 		this.logsVisualizationManager.load();


### PR DESCRIPTION
Description:

* Signing into the panel from external services with different user accounts should not load as the first user second time.
* Report header should not be cut off from bottom when viewing tables anymore.
* Long report titles should not show a scrollbar anymore.
* Filter, Info any query overlays in a report should not overlap the report header anymore.
* Report list and dashboard list on dashboard page now loads in parallel making dashboard loading faster.
* Null and numerical values in a multi-select's name column will not break a global filter anymore.