### PR TITLE
POST changed to GET for query params length less then 62000 in report…

### DIFF
--- a/client/js/reports.js
+++ b/client/js/reports.js
@@ -98,9 +98,11 @@ class DataSource {
 
 		let response = null;
 
-		const options = {
-			method: 'POST',
-		};
+		const paramsLength = parameters.toString().length;
+
+		const options = { };
+
+		paramsLength <= 62000 ? options.method = 'GET' : options.method = 'POST';
 
 		this.resetError();
 


### PR DESCRIPTION
POST changed to GET for query params length less then 62000 in reports/engine/reports api