### PR TITLE
Header nav is now permanently in the popup menu and a few behavior fixes

### DIFF
--- a/client/css/dashboard.css
+++ b/client/css/dashboard.css
@@ -504,9 +504,13 @@ main #reports > .list.editing {
 
 @media (max-width: 1000px) {
 
-	body > header .menu-toggle {
-		display: flex;
+
+	body > header {
+		grid-template-columns: max-content 1fr max-content;
 	}
+		body > header .menu-toggle {
+			display: flex;
+		}
 
 	main {
 		grid-template-columns: 1fr;

--- a/client/css/dashboard.css
+++ b/client/css/dashboard.css
@@ -1,57 +1,10 @@
-/*Css for nav bar at left only on dashboard page*/
-@media (min-width: 750px) {
-
-	body > header .menu-header-toggle {
-		display: flex;
-		padding: 15px 20px;
-		justify-content: center;
-		align-items: center;
-		transition: background var(--transition-duration);
-	}
-	body > header .menu-header-toggle.selcted {
-		background: #fff;
-		color: #333;
-	}
-	body > header .menu-header-toggle:hover {
-		background: rgba(0, 0, 0, 0.25);
-		cursor: pointer;
-	}
-	body > header .nav-container .global-search {
-		margin-left: auto;
-	}
-	body > header .nav-container nav.toggle-right {
-		position: absolute;
-		display: grid;
-		right: 0;
-		top: 50px;
-		background: #fff;
-		box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
-	}
-		body > header .nav-container nav.toggle-right a {
-			color: #333;
-		}
-		body > header .nav-container nav.toggle-right a:hover {
-			background: rgba(0, 0, 0, 0.15);
-		}
-}
-@media (max-width: 750px) {
-
-	body > header .menu-header-toggle {
-		display: none !important;
-	}
-		body > header .nav-container nav {
-			display: block !important;
-		}
-}
-/*end*/
-
 main {
 	display: grid !important;
 	grid-template-rows: 1fr max-content;
 	grid-template-columns: 220px calc(100% - 220px);
 }
 
-header > .nav-toggle {
+header > .menu-toggle {
 	display: none;
 	padding: 15px 20px;
 	color: var(--color-primary-text);
@@ -60,13 +13,13 @@ header > .nav-toggle {
 	justify-content: center;
 	white-space: nowrap;
 }
-header > .nav-toggle:hover {
+header > .menu-toggle:hover {
 	text-decoration: none;
 	background: rgba(255, 255, 255, 0.3);
 	cursor: pointer;
 	transition: box-shadow var(--transition-duration);
 }
-header > .nav-toggle:active {
+header > .menu-toggle:active {
 	background: rgba(255, 255, 255, 0.3);
 	box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2);
 }
@@ -551,7 +504,7 @@ main #reports > .list.editing {
 
 @media (max-width: 750px) {
 
-	header .nav-toggle {
+	body > header .menu-toggle {
 		display: flex;
 	}
 
@@ -601,7 +554,7 @@ main #reports > .list.editing {
 					}
 }
 
-body.floating header > .nav-toggle  {
+body.floating header > .menu-toggle  {
 	display: flex;
 }
 body.floating main  {

--- a/client/css/dashboard.css
+++ b/client/css/dashboard.css
@@ -502,7 +502,7 @@ main #reports > .list.editing {
 					max-height: calc(100vh - 200px);
 				}
 
-@media (max-width: 750px) {
+@media (max-width: 1000px) {
 
 	body > header .menu-toggle {
 		display: flex;

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -226,6 +226,8 @@ body {
 		}
 			body > header nav a {
 				padding: 15px 20px;
+				letter-spacing: 1px;
+				color: #222;
 				transition: background var(--transition-duration),
 							color var(--transition-duration),
 							box-shadow var(--transition-duration);
@@ -243,7 +245,6 @@ body {
 				box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2)
 			}
 		body > header .user-toggle,
-		body > header .menu-toggle,
 		body > header .nav-toggle {
 			display: flex;
 			color: var(--color-secondary-text);
@@ -313,10 +314,6 @@ body {
 				text-decoration: underline;
 				cursor: pointer;
 			}
-		body > header .menu-toggle {
-			display: none;
-			margin-left: auto;
-		}
 
 		@media (max-width: 750px) {
 
@@ -331,6 +328,7 @@ body {
 				body > header .logo {
 					order: 2;
 					margin: 0 auto;
+					height: 50px;
 				}
 				body > header .nav-toggle {
 					order: 3;

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -214,139 +214,162 @@ body {
 				max-width: 85%;
 				height: 80%;
 			}
-		body > header .nav-container {
+		body > header nav {
 			display: flex;
-			width: 100%;
-			background: var(--color-secondary);
+			flex-direction: column;
+			margin-right: auto;
+			background: #fff;
+			position: absolute;
+			right: 0;
+			top: 100%;
+			box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
 		}
-			body > header nav {
-				display: flex;
-				margin-right: auto;
-			}
-			body > header nav > a,
-			body > header .user-toggle,
-			body > header .menu-toggle {
-				display: flex;
-				color: var(--color-secondary-text);
+			body > header nav a {
 				padding: 15px 20px;
-				letter-spacing: 1px;
-				transition: background var(--transition-duration);
-				align-items: center;
-				white-space: nowrap;
+				transition: background var(--transition-duration),
+							color var(--transition-duration),
+							box-shadow var(--transition-duration);
 			}
-			body > header a:hover,
-			body > header .menu-toggle:hover {
+			body > header nav a.selected {
+				background: rgba(0, 0, 0, 0.1);
+			}
+			body > header nav a:hover {
 				text-decoration: none;
-				background: rgba(255, 255, 255, 0.3);
+				background: var(--color-accent);
+				color: #fff;
+			}
+			body > header nav a:active {
+				color: inherit;
+				box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2)
+			}
+		body > header .user-toggle,
+		body > header .menu-toggle,
+		body > header .nav-toggle {
+			display: flex;
+			color: var(--color-secondary-text);
+			padding: 15px 20px;
+			letter-spacing: 1px;
+			transition: background var(--transition-duration);
+			align-items: center;
+			white-space: nowrap;
+		}
+		body > header .menu-toggle:hover,
+		body > header .nav-toggle:hover {
+			text-decoration: none;
+			background: rgba(255, 255, 255, 0.3);
+			cursor: pointer;
+			transition: box-shadow var(--transition-duration);
+		}
+
+		body > header .selected,
+		body > header .menu-toggle:active,
+		body > header .nav-toggle:active {
+			background: rgba(255, 255, 255, 0.3);
+			box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2);
+		}
+
+		body > header .global-search {
+			width: 250px;
+			align-self:  center;
+			margin: 0 10px 0 auto;
+		}
+
+		body > header .user-toggle {
+			white-space: nowrap;
+			display: flex;
+		}
+		body > header .user-popup {
+			position: absolute;
+			right: 0;
+			top: 100%;
+			background: #fff;
+			box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+			color: #333;
+			padding: calc(var(--gap) * 2);
+			display: flex;
+			width: 250px;
+			flex-wrap: wrap;
+		}
+			body > header .user-popup .name {
+				grid-column: 1 / 3;
+				font-size: 125%;
+				font-weight: bold;
+				margin-bottom:  var(--gap);
+				width: 100%;
+			}
+			body > header .user-popup .email {
+				color: #999;
+				width: 100%;
+				margin-bottom: calc(var(--gap) * 2);
+				user-select: text;
+			}
+			body > header .user-popup .profile {
+				margin: var(--gap) var(--gap) 0 0;
+			}
+			body > header .user-popup .logout {
+				margin: var(--gap) 0 0 var(--gap);
+			}
+			body > header .user-popup a:hover {
+				text-decoration: underline;
 				cursor: pointer;
-				transition: box-shadow var(--transition-duration);
 			}
-			body > header a:active,
-			body > header .selected,
-			body > header .menu-toggle:active {
-				background: rgba(255, 255, 255, 0.3);
-				box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.2);
-			}
-
-			body > header .global-search {
-				width: 250px;
-				align-self:  center;
-				margin: 0 10px;
-			}
-
-			body > header .user-toggle {
-				white-space: nowrap;
-				display: flex;
-			}
-			body > header .user-popup {
-				position: absolute;
-				right: 0;
-				top: 100%;
-				background: #fff;
-				box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
-				color: #333;
-				padding: calc(var(--gap) * 2);
-				display: flex;
-				width: 250px;
-				flex-wrap: wrap;
-			}
-				body > header .user-popup .name {
-					grid-column: 1 / 3;
-					font-size: 125%;
-					font-weight: bold;
-					margin-bottom:  var(--gap);
-					width: 100%;
-				}
-				body > header .user-popup .email {
-					color: #999;
-					width: 100%;
-					margin-bottom: calc(var(--gap) * 2);
-					user-select: text;
-				}
-				body > header .user-popup .profile-link {
-					margin: var(--gap) var(--gap) 0 0;
-				}
-				body > header .user-popup .logout {
-					margin: var(--gap) 0 0 var(--gap);
-				}
-				body > header .user-popup a:hover {
-					text-decoration: underline;
-					cursor: pointer;
-				}
-			body > header .menu-toggle {
-				display: none;
-				margin-left: auto;
-			}
+		body > header .menu-toggle {
+			display: none;
+			margin-left: auto;
+		}
 
 		@media (max-width: 750px) {
 
-			body > header .logo {
-				margin-left: auto;
+			body > header {
+				height: auto;
+				display: grid;
+				grid-template-columns: max-content 1fr max-content;
 			}
-			body > header .nav-container {
-				display: none;
-				flex-direction: column;
-				background: var(--color-secondary);
-				position: absolute;
-				top: 100%;
-			}
-			body > header .nav-container.show {
-				display: flex;
-			}
-				body > header nav {
-					flex-direction: column;
+				body > header .menu-toggle {
+					order: 1;
+				}
+				body > header .logo {
+					order: 2;
+					margin: 0 auto;
+				}
+				body > header .nav-toggle {
 					order: 3;
-					margin: 0;
-					padding: calc(var(--gap) * 2) 0;
+				}
+				body > header .global-search {
+					display: none;
+					order: 4;
+					grid-column: 1 / 4;
+					width: 100%;
+					border-bottom: 1px solid #ccc;
+				}
+				body > header .global-search.show {
+					display: initial;
+				}
+					body > header .global-search > input.search-input {
+						border-radius: 0;
+						padding: 10px;
+						height: auto;
+					}
+				body > header .user-popup.show {
+					display: flex !important;
+					position: static;
+					order: 5;
+					width: 100%;
+					grid-column: 1 / 4;
+					box-shadow: none;
+					border-bottom: 1px dashed #ccc;
 				}
 				body > header .user-toggle {
 					display: none;
 				}
-				body > header .user-popup {
+				body > header nav {
 					position: static;
-					display: flex !important;
-					order: 2;
-					background: transparent;
-					color: #fff;
-					padding: 10px 20px;
-					box-shadow: none;
+					order: 6;
+					grid-column: 1 / 4;
 					width: 100%;
-					border-bottom: 1px dashed #999;
+					box-shadow: none;
 				}
-					body > header .user-popup a {
-						color: #fff;
-					}
-					body > header .user-popup .email {
-						color: #ccc;
-					}
-				body > header .global-search {
-					order: 1;
-					width: calc(100% - 40px);
-					margin: 10px 20px;
-				}
-			body > header .menu-toggle {
-				display: flex;
-			}
+
 			main .dialog-box {
 				width: calc(100% - calc(var(--gap) * 3)) !important;
 				max-height: calc(100% - calc(var(--gap) * 10));

--- a/client/css/main.css
+++ b/client/css/main.css
@@ -320,7 +320,7 @@ body {
 			body > header {
 				height: auto;
 				display: grid;
-				grid-template-columns: max-content 1fr max-content;
+				grid-template-columns: 1fr max-content;
 			}
 				body > header .menu-toggle {
 					order: 1;

--- a/client/css/reports.css
+++ b/client/css/reports.css
@@ -255,7 +255,7 @@ main .dataset {
 			.data-source > .menu .item:hover > .label {
 				background: var(--color-accent);
 				cursor: pointer;
-				color: #fff;
+				color: var(--color-accent-text);
 			}
 			.data-source > .menu .item.selected > .label {
 				background: var(--color-selected);

--- a/client/index.js
+++ b/client/index.js
@@ -86,25 +86,6 @@ class HTMLAPI extends API {
 
 					<div id="ajax-working"></div>
 
-					<header>
-						<a class="logo" href="/dashboard/first"><img></a>
-
-						<div class="nav-container">
-
-							<nav></nav>
-
-							<span class="user-toggle"></span>
-
-							<div class="user-popup hidden">
-								<span class="name"></span>
-								<span class="email"></span>
-								<a href="#" class="logout">Logout</a>
-							</div>
-						</div>
-
-						<div class="menu-toggle"><i class="fas fa-chevron-down"></i></div>
-					</header>
-
 					<main>
 						${this.main ? await this.main() || '' : ''}
 					</main>

--- a/client/js/dashboard.js
+++ b/client/js/dashboard.js
@@ -9,23 +9,22 @@ Page.class = class Dashboards extends Page {
 		this.list = new Map;
 		this.loadedVisualizations = new Set;
 		this.nav = document.querySelector('main > nav');
-		//document.querySelector('body').classList.add('floating');
 
 		this.listContainer = this.container.querySelector('section#list');
 		this.reports = this.container.querySelector('section#reports');
 		this.listContainer.form = this.listContainer.querySelector('.form.toolbar');
 
-		const navToggle = document.createElement('span');
-		navToggle.classList.add('nav-toggle');
-		navToggle.innerHTML = `<i class="fa fa-bars"></i>`;
-		document.querySelector('header').insertAdjacentElement('afterbegin', navToggle);
+		const menuToggle = document.createElement('span');
+		menuToggle.classList.add('menu-toggle');
+		menuToggle.innerHTML = `<i class="fa fa-bars"></i>`;
+		document.querySelector('header').insertAdjacentElement('afterbegin', menuToggle);
 
 		const navBlanket = this.container.querySelector('.nav-blanket');
 
-		navToggle.on('click', () => {
+		menuToggle.on('click', () => {
 			this.nav.classList.toggle('show');
 			navBlanket.classList.toggle('hidden');
-			navToggle.classList.toggle('selected');
+			menuToggle.classList.toggle('selected');
 			this.container.querySelector('.nav-blanket').classList.toggle('hidden', !this.nav.classList.contains('show'));
 		});
 
@@ -33,7 +32,7 @@ Page.class = class Dashboards extends Page {
 
 			this.nav.classList.remove('show');
 			navBlanket.classList.add('hidden');
-			navToggle.classList.remove('selected');
+			menuToggle.classList.remove('selected');
 			this.container.querySelector('.nav-blanket').classList.toggle('hidden', !this.nav.classList.contains('show'));
 		});
 
@@ -54,56 +53,17 @@ Page.class = class Dashboards extends Page {
 			history.pushState(null, '', window.location.pathname.slice(0, window.location.pathname.lastIndexOf('/')));
 		});
 
-		for (const category of MetaData.categories.values()) {
-
+		for(const category of MetaData.categories.values())
 			this.listContainer.form.subtitle.insertAdjacentHTML('beforeend', `<option value="${category.category_id}">${category.name}</option>`);
-		}
-
-		const menuBar = document.querySelector('header');
-		menuBar.querySelector('.nav-container nav').classList.add('toggle-right', 'hidden');
-		menuBar.appendChild(this.menuBarToggle);
-
-		document.querySelector('body').on('click', () => {
-			menuBar.querySelector('.menu-header-toggle').classList.remove('selected');
-			document.querySelector('.nav-container nav').classList.add('hidden');
-		})
 
 		this.listContainer.form.subtitle.on('change', () => this.renderList());
 		this.listContainer.form.search.on('keyup', () => this.renderList());
 
-		window.on('popstate', e => {
-			this.load(e.state)
-		});
+		window.on('popstate', e => this.load(e.state));
 
 		this.navbar = new Navbar(new Map, this);
 
-		(async () => {
-
-			await this.load();
-		})();
-	}
-
-	get menuBarToggle() {
-
-		if (this.menuBarToggleElement)
-			return this.menuBarToggleElement;
-
-		const div = this.element = document.createElement('div');
-		div.classList.add('menu-header-toggle');
-
-		div.innerHTML = `
-			<i class="fas fa-chevron-down"></i>
-		`;
-
-		div.on('click', (e) => {
-
-			e.stopPropagation();
-
-			div.classList.toggle('selected');
-			document.querySelector('.nav-container nav').classList.toggle('hidden');
-		})
-
-		return div;
+		this.load();
 	}
 
 	get currentDashboard() {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -122,6 +122,9 @@ class Page {
 
 	renderPage() {
 
+		if(!this.account || !this.user)
+			return;
+
 		document.body.insertBefore(this.header.container, this.container);
 
 		if(window.account) {

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -337,7 +337,12 @@ class PageHeader {
 			userPopup.classList.toggle('show');
 		});
 
-		container.querySelector('.logout').on('click', () => User.logout());
+		container.querySelector('.logout').on('click', () => {
+
+			Cookies.set('bypassLogin', '');
+
+			User.logout();
+		});
 
 		userPopup.on('click', e => e.stopPropagation());
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -111,6 +111,7 @@ class Page {
 
 		this.serviceWorker = new Page.serviceWorker(this);
 		this.webWorker = new Page.webWorker(this);
+		this.header = new PageHeader(this);
 
 		if(container)
 			return;
@@ -121,95 +122,14 @@ class Page {
 
 	renderPage() {
 
-		const
-			navList = [
-				{url: '/users-manager', name: 'Users', privileges: ['user.list', 'user'], icon: 'fas fa-users'},
-				{url: '/dashboards-manager', name: 'Dashboards', privileges: [], icon: 'fa fa-newspaper'},
-				{url: '/reports', name: 'Reports', privileges: [], icon: 'fa fa-database'},
-				{url: '/visualizations-manager', name: 'Visualizations', privileges: [], icon: 'far fa-chart-bar'},
-				{url: '/connections-manager', name: 'Connections', privileges: ['connection', 'connection.list'], icon: 'fa fa-server'},
-				{url: '/settings', name: 'Settings', privileges: ['administrator', 'category.insert', 'category.update', 'category.delete'], icon: 'fas fa-cog'},
-			],
-			header = document.querySelector('body > header'),
-			navContainer = header.querySelector('.nav-container'),
-			nav = header.querySelector('nav'),
-			userPopup = header.querySelector('.user-popup'),
-			userToggle = header.querySelector('.user-toggle'),
-			menuToggle = header.querySelector('.menu-toggle'),
-			profileLink = document.createElement('a');
+		document.body.insertBefore(this.header.container, this.container);
 
 		if(window.account) {
-
-			if(account.settings.get('hideHeader')) {
-				header.classList.add('hidden');
-				return;
-			}
 
 			if(account.icon)
 				document.getElementById('favicon').href = account.icon;
 
-			if(account.logo)
-				header.querySelector('.logo img').src = account.logo;
-
 			document.title = account.name;
-		}
-
-		userToggle.innerHTML = '<i class="fa fa-user"></i>&nbsp; '+ this.user.name;
-
-		profileLink.textContent = 'Profile';
-		profileLink.href = `/user/profile/${this.user.user_id}`;
-		profileLink.classList.add('profile-link');
-
-		header.querySelector('.name').innerHTML = this.user.name;
-		header.querySelector('.email').innerHTML = this.user.email;
-		header.querySelector('.user-popup').insertBefore(profileLink, header.querySelector('.logout'));
-
-		userToggle.on('click', e => {
-			e.stopPropagation();
-			userPopup.classList.toggle('hidden');
-			userToggle.classList.toggle('selected');
-		});
-
-		document.body.on('click', () => {
-			userPopup.classList.add('hidden');
-			userToggle.classList.remove('selected');
-			navContainer.classList.remove('show');
-			menuToggle.classList.remove('selected');
-		});
-
-		userPopup.on('click', e => e.stopPropagation());
-		navContainer.on('click', e => e.stopPropagation());
-
-		header.querySelector('.logout').on('click', () => {
-			Cookies.set('bypassLogin', '')
-			User.logout();
-		});
-
-		menuToggle.on('click', e => {
-			e.stopPropagation();
-			navContainer.classList.toggle('show');
-			menuToggle.classList.toggle('selected');
-		});
-
-		if(user.id)
-			navContainer.insertBefore(new GlobalSearch().container, header.querySelector('.user-toggle'));
-
-		for(const item of navList) {
-
-			if(!window.user || (item.privileges.every(p => !user.privileges.has(p)) && item.privileges.length))
-				continue;
-
-			nav.insertAdjacentHTML('beforeend',`
-				<a href='${item.url}'>
-					<i class="${item.icon}"></i>&nbsp;
-					${item.name}
-				</a>
-			`);
-		}
-
-		for(const item of nav.querySelectorAll('a')) {
-			if(window.location.pathname.startsWith(new URL(item.href).pathname))
-				item.classList.add('selected');
 		}
 	}
 
@@ -293,6 +213,144 @@ class Page {
 			document.head.appendChild(onboardScript);
 			document.head.appendChild(onboardCSS);
 		}
+	}
+}
+
+class PageHeader {
+
+	constructor(page) {
+
+		this.page = page;
+
+		this.globalSearch = new GlobalSearch();
+	}
+
+	get container() {
+
+		if(this.containerElement)
+			return this.containerElement;
+
+		const container = this.containerElement = document.createElement('header');
+
+		container.innerHTML = `
+
+			<a class="logo" href="/dashboard/first"><img src="${this.page.account.logo}"></a>
+
+			<span class="user-toggle"><i class="fa fa-user"></i>&nbsp; ${this.page.user.name || ''}</span>
+
+			<div class="user-popup hidden">
+				<span class="name">${this.page.user.name}</span>
+				<span class="email">${this.page.user.email}</span>
+				<a href="/user/profile/${this.page.user.user_id}" class="profile">Profile</a>
+				<a href="#" class="logout">Logout</a>
+			</div>
+
+			<div class="nav-toggle"><i class="fas fa-chevron-down"></i></div>
+
+			<nav class="hidden"></nav>
+		`;
+
+		const
+			navList = [
+				{
+					url: '/users-manager',
+					name: 'Users',
+					privileges: ['user.list', 'user'],
+					icon: 'fas fa-users',
+				},
+				{
+					url: '/dashboards-manager',
+					name: 'Dashboards',
+					privileges: [],
+					icon: 'fa fa-newspaper',
+				},
+				{
+					url: '/reports',
+					name: 'Reports',
+					privileges: [],
+					icon: 'fa fa-database',
+				},
+				{
+					url: '/visualizations-manager',
+					name: 'Visualizations',
+					privileges: [],
+					icon: 'far fa-chart-bar',
+				},
+				{
+					url: '/connections-manager',
+					name: 'Connections',
+					privileges: ['connection', 'connection.list'],
+					icon: 'fa fa-server',
+				},
+				{
+					url: '/settings',
+					name: 'Settings',
+					privileges: ['administrator', 'category.insert', 'category.update', 'category.delete'],
+					icon: 'fas fa-cog',
+				},
+			],
+			nav = container.querySelector('nav'),
+			navToggle = container.querySelector('.nav-toggle'),
+			userToggle = container.querySelector('.user-toggle'),
+			userPopup = container.querySelector('.user-popup');
+
+		for(const item of navList) {
+
+			if((item.privileges.every(p => !this.page.user.privileges.has(p)) && item.privileges.length))
+				continue;
+
+			nav.insertAdjacentHTML('beforeend',`
+				<a href="${item.url}" class="${window.location.pathname.startsWith(item.url) ? 'selected' : ''}">
+					<i class="${item.icon}"></i>&nbsp;
+					${item.name}
+				</a>
+			`);
+		}
+
+		container.insertBefore(this.globalSearch.container, userToggle);
+
+		userToggle.on('click', e => {
+
+			e.stopPropagation();
+
+			nav.classList.add('hidden');
+			navToggle.classList.remove('selected');
+
+			userPopup.classList.toggle('hidden');
+			userToggle.classList.toggle('selected');
+		});
+
+		navToggle.on('click', e => {
+
+			e.stopPropagation();
+
+			userPopup.classList.add('hidden');
+			userToggle.classList.remove('selected');
+
+			nav.classList.toggle('hidden');
+			navToggle.classList.toggle('selected');
+
+			this.globalSearch.container.classList.toggle('show');
+			userPopup.classList.toggle('show');
+		});
+
+		container.querySelector('.logout').on('click', () => User.logout());
+
+		userPopup.on('click', e => e.stopPropagation());
+
+		document.on('click', () => {
+
+			userPopup.classList.add('hidden');
+			userToggle.classList.remove('selected');
+
+			nav.classList.add('hidden');
+			navToggle.classList.remove('selected');
+
+			this.globalSearch.container.classList.remove('show');
+			userPopup.classList.remove('show');
+		});
+
+		return container;
 	}
 }
 


### PR DESCRIPTION
Description:

- Top nav bar is now always in the popup.
- Opening user popup (top right) while menu (also top right) is open and vice versa now closes the other before opening the new menu.
- On phone, the background for search, profile and menu items is now white.
- The top header will not overflow on smaller screens anymore. (macbook air, ipad, etc, not phones)